### PR TITLE
Move dimensions to its own file

### DIFF
--- a/src/CapabilityFactory.js
+++ b/src/CapabilityFactory.js
@@ -1,4 +1,4 @@
-import {BROWSER, DEVICE, OPERATING_SYSTEM, ORIENTATION, RESOLUTION} from "./TestCaseGenerator";
+import {BROWSER, DEVICE, OPERATING_SYSTEM, ORIENTATION, RESOLUTION} from "./Dimensions";
 
 const OPERATING_SYSTEM_NAMES = new Map( [
 	[ 'win7', 'Windows 7' ],

--- a/src/ConfigurationParser.js
+++ b/src/ConfigurationParser.js
@@ -1,5 +1,7 @@
+import {BANNER as BANNER_DIMENSION} from "./Dimensions";
+
 const toml = require( 'toml' );
-import {TestCaseGenerator, BANNER as BANNER_DIMENSION} from "./TestCaseGenerator";
+import {TestCaseGenerator} from "./TestCaseGenerator";
 import objectToMap from "./ObjectToMap";
 
 const PREVIEW_URL = 'preview_url';

--- a/src/Dimensions.js
+++ b/src/Dimensions.js
@@ -1,0 +1,7 @@
+export const BANNER = 'banner';
+export const BROWSER = 'browser';
+export const DEVICE = 'device';
+export const OPERATING_SYSTEM = 'operating_system';
+export const ORIENTATION = 'orientation';
+export const RESOLUTION = 'resolution';
+export const ALLOWED_DIMENSIONS = [BANNER, BROWSER, DEVICE, OPERATING_SYSTEM, ORIENTATION, RESOLUTION];

--- a/src/TestCase.js
+++ b/src/TestCase.js
@@ -1,4 +1,4 @@
-import { BROWSER, DEVICE, OPERATING_SYSTEM, RESOLUTION } from "./TestCaseGenerator";
+import {BROWSER, DEVICE, OPERATING_SYSTEM, RESOLUTION} from "./Dimensions";
 
 const BROWSERS_EXCLUDED_OPERATING_SYSTEMS = [
 	{

--- a/src/TestCaseGenerator.js
+++ b/src/TestCaseGenerator.js
@@ -1,14 +1,6 @@
 import cartesian from './Cartesian';
-import { TestCase } from "./TestCase";
-
-export const BANNER = 'banner';
-export const BROWSER = 'browser';
-export const DEVICE = 'device';
-export const OPERATING_SYSTEM = 'operating_system';
-export const ORIENTATION = 'orientation';
-export const RESOLUTION = 'resolution';
-
-const ALLOWED_DIMENSIONS = [ BANNER, BROWSER, DEVICE, OPERATING_SYSTEM, ORIENTATION, RESOLUTION ];
+import {TestCase} from "./TestCase";
+import {ALLOWED_DIMENSIONS, BANNER, BROWSER, DEVICE, OPERATING_SYSTEM} from "./Dimensions";
 
 export class TestCaseGenerator {
 	testCases;

--- a/test/specs/CapabilityFactory.js
+++ b/test/specs/CapabilityFactory.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
-import {TestCaseGenerator, BANNER, RESOLUTION, BROWSER, OPERATING_SYSTEM, DEVICE} from "../../src/TestCaseGenerator";
 import { CapabilityFactory } from "../../src/CapabilityFactory";
 import { TestCase } from "../../src/TestCase";
+import {BANNER, BROWSER, DEVICE, OPERATING_SYSTEM, RESOLUTION} from "../../src/Dimensions";
 
 
 

--- a/test/specs/TestCase.js
+++ b/test/specs/TestCase.js
@@ -1,7 +1,8 @@
+import {BANNER, BROWSER, OPERATING_SYSTEM, RESOLUTION} from "../../src/Dimensions";
+
 const assert = require('assert');
 
 import { TestCase, INVALID_REASON_REQUIRED, INVALID_REASON_BROWSER, INVALID_REASON_RESOLUTION } from "../../src/TestCase";
-import { BANNER, BROWSER, OPERATING_SYSTEM, RESOLUTION } from "../../src/TestCaseGenerator";
 
 describe('TestCase', () => {
 	const dimensions = [OPERATING_SYSTEM, BROWSER, RESOLUTION, BANNER];

--- a/test/specs/TestCaseGenerator.js
+++ b/test/specs/TestCaseGenerator.js
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
-import {TestCaseGenerator, BANNER, DEVICE, BROWSER, OPERATING_SYSTEM} from "../../src/TestCaseGenerator";
+import {TestCaseGenerator} from "../../src/TestCaseGenerator";
+import {BANNER, BROWSER, DEVICE, OPERATING_SYSTEM} from "../../src/Dimensions";
 
 const BANNER_URL = 'http://de.wikipedia.org/{{PLACEHOLDER}}';
 const PLACEHOLDER = '{{PLACEHOLDER}}';


### PR DESCRIPTION
It's referenced in many places and not part of of TestCaseGenerator.

As a single file, it can also be reused in Shutterbug.