### PR TITLE
Adjust scripts for linux

### DIFF
--- a/metadata_summary.js
+++ b/metadata_summary.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node -r esm
+// this interpeter call does not work on linux machines: 
+// https://unix.stackexchange.com/questions/63979/shebang-line-with-usr-bin-env-command-argument-fails-on-linux
 
 import glob from 'glob'
 import * as path from 'path';

--- a/remote_metadata_summary.sh
+++ b/remote_metadata_summary.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# needs bash on linux machines to work properly
 
 if [ -z "$1" ]; then
   echo "You must provide the remote server name!"


### PR DESCRIPTION
Two of the scripts only run corrently on iOS environments,
different shells and environment/path handling leads to errors on linux.

See:
https://unix.stackexchange.com/questions/63979/shebang-line-with-usr-bin-env-command-argument-fails-on-linux

https://github.com/localtunnel/server/issues/90