### PR TITLE
Use ES6 modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To run the tool, you need to set your testingbot credentials. You can get them b
 
 Then you can run the screenshot tool:
 
-    node -r esm index.js -c ../fundraising-banners/campaign_info.toml <CAMPAIGN_NAME>
+    node index.js -c ../fundraising-banners/campaign_info.toml <CAMPAIGN_NAME>
 
 The `-c` parameter is for locating the campaign configuration from the
 [`wmde/fundraising-banners`
@@ -89,7 +89,7 @@ im- and export it in `src/test_functions/index.js` and specify its name in
 ## Updating the screenshot metadata
 To update the metadata summary for the [Shutterbug UI](https://github.com/wmde/shutterbug), run the command
 
-    node -r esm ./metadata_summary.js
+    node ./metadata_summary.js
 
 Without any parameters, this will search the `banner-shots` directory for campaign directories and process their 
 `metadata.json` files. 
@@ -108,4 +108,4 @@ The user needs write access in the specified directory!
 
 Use the following command to run individual tests
 
-    node_modules/.bin/mocha -r esm test/specs/name_of_your_test.js 
+    npx mocha test/specs/name_of_your_test.js 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,16 @@
-import { BrowserFactory, CONNECTION, factoryOptions } from "./src/TBBrowserFactory";
-import {CapabilityFactory} from "./src/TBCapabilityFactory";
-import {TBBatchRunner} from "./src/TBBatchRunner";
-import {CliRequestFactory} from "./src/CliRequestFactory";
-import {ScreenshotGenerator} from "./src/ScreenshotGenerator";
+import { URL } from 'url';
+import { BrowserFactory, CONNECTION, factoryOptions } from "./src/TBBrowserFactory.js";
+import {CapabilityFactory} from "./src/TBCapabilityFactory.js";
+import {TBBatchRunner} from "./src/TBBatchRunner.js";
+import {CliRequestFactory} from "./src/CliRequestFactory.js";
+import {ScreenshotGenerator} from "./src/ScreenshotGenerator.js";
 
 const browserFactory = new BrowserFactory( CONNECTION,
 	new CapabilityFactory( factoryOptions )
 );
 const batchRunner = new TBBatchRunner( browserFactory );
 const screenshotGenerator = new ScreenshotGenerator( batchRunner );
-const requestFactory = new CliRequestFactory( __dirname );
+const requestFactory = new CliRequestFactory( new URL( '.', import.meta.url ).pathname );
 
 screenshotGenerator.generateScreenshots( requestFactory.getRequestParameters() )
 	.then ( testcases => {

--- a/metadata_summary.js
+++ b/metadata_summary.js
@@ -1,10 +1,10 @@
-#!/usr/bin/env node -r esm
+#!/usr/bin/env node
 
 import glob from 'glob'
 import * as path from 'path';
 import * as fs from 'fs';
 import meow from "meow";
-import MetadataSummarizer from "./src/MetadataSummarizer";
+import MetadataSummarizer from "./src/MetadataSummarizer.js";
 
 const SUMMARY_FILENAME = 'metadata_summary.json';
 

--- a/metadata_summary.js
+++ b/metadata_summary.js
@@ -30,7 +30,8 @@ const cli = meow(
 				type: 'string',
 				default: SUMMARY_FILENAME
 			}
-		}
+		},
+		importMeta: import.meta
 	} );
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "glob": "^7.2.0",
-        "meow": "^9.0",
+        "meow": "^10.0",
         "partition-all": "^1.0.1",
         "promise-queue": "^2.2.5",
         "toml": "^3.0.0",
@@ -1253,7 +1253,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1262,35 +1261,31 @@
       }
     },
     "node_modules/camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.1.tgz",
+      "integrity": "sha512-P331lEls98pW8JLyodNWfzuz91BEDVA4VpW2/SwXnyv2K495tq1N777xzDbFgnEigfA7UIY0xa6PwR/H9jijjA==",
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
+        "camelcase": "^6.2.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+    "node_modules/camelcase-keys/node_modules/type-fest": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/quick-lru": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {
@@ -2010,7 +2005,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2394,6 +2388,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2931,7 +2926,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -3074,23 +3068,34 @@
       "integrity": "sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ=="
     },
     "node_modules/meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.1.tgz",
+      "integrity": "sha512-uzOAEBTGujHAD6bVzIQQk5kDTgatxmpVmr1pj9QhwsHLEG2AiB+9F08/wmjrZIk4h5pWxERd7+jqGZywYx3ZFw==",
       "dependencies": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
       },
+      "engines": {
+        "node": ">=12.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/decamelize": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+      "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA==",
       "engines": {
         "node": ">=10"
       },
@@ -3099,9 +3104,9 @@
       }
     },
     "node_modules/meow/node_modules/type-fest": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
         "node": ">=10"
       },
@@ -3453,7 +3458,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3468,7 +3472,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -3555,7 +3558,8 @@
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -3870,121 +3874,58 @@
       "dev": true
     },
     "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "dependencies": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-    },
-    "node_modules/read-pkg/node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-      "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "bin": {
-        "semver": "bin/semver"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/readable-stream": {
@@ -4033,15 +3974,29 @@
       }
     },
     "node_modules/redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/redent/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/regenerator-runtime": {
@@ -4062,6 +4017,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "dependencies": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -4383,14 +4339,17 @@
       }
     },
     "node_modules/strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "dependencies": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4552,11 +4511,14 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "node_modules/trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew==",
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tslib": {
@@ -4958,7 +4920,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5965,28 +5926,23 @@
     "camelcase": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-      "dev": true
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
     },
     "camelcase-keys": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-7.0.1.tgz",
+      "integrity": "sha512-P331lEls98pW8JLyodNWfzuz91BEDVA4VpW2/SwXnyv2K495tq1N777xzDbFgnEigfA7UIY0xa6PwR/H9jijjA==",
       "requires": {
-        "camelcase": "^5.3.1",
-        "map-obj": "^4.0.0",
-        "quick-lru": "^4.0.1"
+        "camelcase": "^6.2.0",
+        "map-obj": "^4.1.0",
+        "quick-lru": "^5.1.1",
+        "type-fest": "^1.2.1"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
-        },
-        "quick-lru": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-          "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g=="
+        "type-fest": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
@@ -6546,7 +6502,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -6809,7 +6764,8 @@
     "indent-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -7239,7 +7195,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "requires": {
         "p-locate": "^5.0.0"
       }
@@ -7351,28 +7306,33 @@
       "integrity": "sha512-k1dB2HNeaNyORco8ulVEhctyEGkKHb2YWAhDsxeFlW2nROIirsctBYzKwwS3Vza+sKTS1zO4Z+n9/+9WbGLIxQ=="
     },
     "meow": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-10.1.1.tgz",
+      "integrity": "sha512-uzOAEBTGujHAD6bVzIQQk5kDTgatxmpVmr1pj9QhwsHLEG2AiB+9F08/wmjrZIk4h5pWxERd7+jqGZywYx3ZFw==",
       "requires": {
-        "@types/minimist": "^1.2.0",
-        "camelcase-keys": "^6.2.2",
-        "decamelize": "^1.2.0",
+        "@types/minimist": "^1.2.2",
+        "camelcase-keys": "^7.0.0",
+        "decamelize": "^5.0.0",
         "decamelize-keys": "^1.1.0",
         "hard-rejection": "^2.1.0",
         "minimist-options": "4.1.0",
-        "normalize-package-data": "^3.0.0",
-        "read-pkg-up": "^7.0.1",
-        "redent": "^3.0.0",
-        "trim-newlines": "^3.0.0",
-        "type-fest": "^0.18.0",
-        "yargs-parser": "^20.2.3"
+        "normalize-package-data": "^3.0.2",
+        "read-pkg-up": "^8.0.0",
+        "redent": "^4.0.0",
+        "trim-newlines": "^4.0.2",
+        "type-fest": "^1.2.2",
+        "yargs-parser": "^20.2.9"
       },
       "dependencies": {
+        "decamelize": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-5.0.1.tgz",
+          "integrity": "sha512-VfxadyCECXgQlkoEAjeghAr5gY3Hf+IKjKb+X8tGVDtveCjN+USwprd2q3QXBR9T1+x2DG0XZF5/w+7HAtSaXA=="
+        },
         "type-fest": {
-          "version": "0.18.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
@@ -7621,7 +7581,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "requires": {
         "yocto-queue": "^0.1.0"
       }
@@ -7630,7 +7589,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "requires": {
         "p-limit": "^3.0.2"
       }
@@ -7687,7 +7645,8 @@
     "path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
     },
     "path-type": {
       "version": "4.0.0",
@@ -7911,91 +7870,37 @@
       "dev": true
     },
     "read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-6.0.0.tgz",
+      "integrity": "sha512-X1Fu3dPuk/8ZLsMhEj5f4wFAF0DWoK7qhGJvgaijocXxBmSToKfbFtqbxMO7bVjNA1dmE5huAzjXj/ey86iw9Q==",
       "requires": {
         "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "normalize-package-data": "^3.0.2",
+        "parse-json": "^5.2.0",
+        "type-fest": "^1.0.1"
       },
       "dependencies": {
-        "hosted-git-info": {
-          "version": "2.8.9",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
-        },
-        "normalize-package-data": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-          "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
-          }
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-        },
         "type-fest": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
     "read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-8.0.0.tgz",
+      "integrity": "sha512-snVCqPczksT0HS2EC+SxUndvSzn6LRCwpfSvLrIfR5BKDQQZMaI6jPRC9dYvYFDRAuFEAnkwww8kBBNE/3VvzQ==",
       "requires": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
+        "find-up": "^5.0.0",
+        "read-pkg": "^6.0.0",
+        "type-fest": "^1.0.1"
       },
       "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
         "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         }
       }
     },
@@ -8036,12 +7941,19 @@
       }
     },
     "redent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-4.0.0.tgz",
+      "integrity": "sha512-tYkDkVVtYkSVhuQ4zBgfvciymHaeuel+zFKXShfDnFP5SyVEP7qo70Rf1jTOTCx3vGNAbnEi/xFkcfQVMIBWag==",
       "requires": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
+        "indent-string": "^5.0.0",
+        "strip-indent": "^4.0.0"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+          "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="
+        }
       }
     },
     "regenerator-runtime": {
@@ -8059,6 +7971,7 @@
       "version": "1.20.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
       "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
@@ -8297,11 +8210,11 @@
       }
     },
     "strip-indent": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.0.0.tgz",
+      "integrity": "sha512-mnVSV2l+Zv6BLpSD/8V87CW/y9EmmbYzGCIavsnsI6/nwn26DwffM/yztm30Z/I2DY9wdS3vXVCMnHDgZaVNoA==",
       "requires": {
-        "min-indent": "^1.0.0"
+        "min-indent": "^1.0.1"
       }
     },
     "strip-json-comments": {
@@ -8431,9 +8344,9 @@
       "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="
     },
     "trim-newlines": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw=="
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-4.0.2.tgz",
+      "integrity": "sha512-GJtWyq9InR/2HRiLZgpIKv+ufIKrVrvjQWEj7PxAXNc5dwbNJkqhAUoAGgzRmULAnoOM5EIpveYd3J2VeSAIew=="
     },
     "tslib": {
       "version": "2.1.0",
@@ -8729,8 +8642,7 @@
     "yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     },
     "zip-stream": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "esm": "^3.2.25",
         "glob": "^7.2.0",
         "meow": "^9.0",
         "partition-all": "^1.0.1",
@@ -28,6 +27,9 @@
         "@wdio/testingbot-service": "^7.13.2",
         "chromedriver": "^94.0.0",
         "wdio-chromedriver-service": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=15.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -142,9 +144,9 @@
       }
     },
     "node_modules/@jest/types": {
-      "version": "27.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -311,9 +313,9 @@
       }
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.173",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-      "integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==",
+      "version": "4.14.175",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
       "dev": true
     },
     "node_modules/@types/lodash.flattendeep": {
@@ -493,19 +495,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@wdio/cli/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@wdio/config": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/@wdio/config/-/config-7.13.2.tgz",
@@ -515,18 +504,6 @@
         "@wdio/types": "7.13.2",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/config/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -552,19 +529,6 @@
       },
       "peerDependencies": {
         "@wdio/cli": "^7.0.0"
-      }
-    },
-    "node_modules/@wdio/local-runner/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/@wdio/logger": {
@@ -593,19 +557,6 @@
         "@wdio/utils": "7.13.2",
         "expect-webdriverio": "^3.0.0",
         "mocha": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/mocha-framework/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -650,19 +601,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/@wdio/reporter/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@wdio/runner": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/@wdio/runner/-/runner-7.13.2.tgz",
@@ -677,19 +615,6 @@
         "gaze": "^1.1.2",
         "webdriver": "7.13.2",
         "webdriverio": "7.13.2"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/runner/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -715,19 +640,6 @@
         "@wdio/cli": "^7.0.0"
       }
     },
-    "node_modules/@wdio/spec-reporter/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/@wdio/testingbot-service": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/@wdio/testingbot-service/-/testingbot-service-7.13.2.tgz",
@@ -748,11 +660,10 @@
         "@wdio/cli": "^7.0.0"
       }
     },
-    "node_modules/@wdio/testingbot-service/node_modules/@wdio/types": {
+    "node_modules/@wdio/types": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
       "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dev": true,
       "dependencies": {
         "@types/node": "^15.12.5",
         "got": "^11.8.1"
@@ -769,18 +680,6 @@
         "@wdio/logger": "7.7.0",
         "@wdio/types": "7.13.2",
         "p-iteration": "^1.1.8"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@wdio/utils/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1351,11 +1250,15 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true,
       "engines": {
-        "node": ">=6"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/camelcase-keys": {
@@ -1372,6 +1275,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-keys/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-keys/node_modules/quick-lru": {
@@ -1598,9 +1509,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "node_modules/core-js-pure": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.0.tgz",
-      "integrity": "sha512-ZnK+9vyuMhKulIGqT/7RHGRok8RtkHMEX/BGPHkHx+ouDkq+MUvf9mfIgdqhpmPDu8+V5UtRn/CbCRc9I4lX4w==",
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.1.tgz",
+      "integrity": "sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -1836,18 +1747,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.925217.tgz",
       "integrity": "sha512-sI7aLeM9VcH1f+HYEGWaPv2RlWmfBCsnHt/rsPzJ4MCyejvx5R5fauW1dll7OIyE6frwXoEzqi7Y0925XdFIKA=="
     },
-    "node_modules/devtools/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/diff": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
@@ -1953,14 +1852,6 @@
         "node": ">=0.8.0"
       }
     },
-    "node_modules/esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/exit-on-epipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
@@ -1970,16 +1861,16 @@
       }
     },
     "node_modules/expect": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
-      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.4.tgz",
+      "integrity": "sha512-gOtuonQ8TCnbNNCSw2fhVzRf8EFYDII4nB5NmG4IEV0rbUnW1I5zXvoTntU4iicB/Uh0oZr20NGlOLdJiwsOZA==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.1",
+        "@jest/types": "^27.2.4",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6"
       },
       "engines": {
@@ -2182,20 +2073,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -2587,9 +2464,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -2630,9 +2507,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -2825,15 +2702,15 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
-      "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.4.tgz",
+      "integrity": "sha512-bLAVlDSCR3gqUPGv+4nzVpEXGsHh98HjUL7Vb2hVyyuBDoQmja8eJb0imUABsuxBeUVmf47taJSAd9nDrwWKEg==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
@@ -2849,33 +2726,33 @@
       }
     },
     "node_modules/jest-matcher-utils": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.0.tgz",
-      "integrity": "sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.4.tgz",
+      "integrity": "sha512-nQeLfFAIPPkyhkDfifAPfP/U5wm1x0fLtAzqXZSSKckXDNuk2aaOfQiDYv1Mgf5GY6yOsxfUnvNm3dDjXM+BXw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.2.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.4"
       },
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
     "node_modules/jest-message-util": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.0.tgz",
-      "integrity": "sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.4.tgz",
+      "integrity": "sha512-wbKT/BNGnBVB9nzi+IoaLkXt6fbSvqUxx+IYY66YFh96J3goY33BAaNG3uPqaw/Sh/FR9YpXGVDfd5DJdbh4nA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.1.1",
+        "@jest/types": "^27.2.4",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       },
@@ -3321,16 +3198,16 @@
       }
     },
     "node_modules/mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "dependencies": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -3341,12 +3218,11 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
@@ -3363,29 +3239,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/mochajs"
       }
-    },
-    "node_modules/mocha/node_modules/debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-      "dev": true,
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mocha/node_modules/debug/node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
     },
     "node_modules/mocha/node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -3464,9 +3317,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -3820,13 +3673,13 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "dev": true,
       "dependencies": {
-        "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -4313,9 +4166,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.1.tgz",
-      "integrity": "sha512-vNenx7gqjPyeKpRnM6S5Ksm/oFTRijWWzYlRON04KaehZ3YjDwEmVjGUGo0TKWVjeNXOujVRlh0K1drUbcdPkw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
       "dev": true,
       "dependencies": {
         "tslib": "~2.1.0"
@@ -4395,9 +4248,9 @@
       }
     },
     "node_modules/signal-exit": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
-      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
     "node_modules/slash": {
@@ -4485,25 +4338,25 @@
       }
     },
     "node_modules/string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -4842,18 +4695,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/webdriver/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/webdriverio": {
       "version": "7.13.2",
       "resolved": "https://registry.npmjs.org/webdriverio/-/webdriverio-7.13.2.tgz",
@@ -4893,18 +4734,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/webdriverio/node_modules/@wdio/types": {
-      "version": "7.13.2",
-      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-      "dependencies": {
-        "@types/node": "^15.12.5",
-        "got": "^11.8.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4917,49 +4746,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^1.0.2 || 2"
-      }
-    },
-    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "dependencies": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/wide-align/node_modules/strip-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/workerpool": {
@@ -5025,9 +4811,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -5063,18 +4849,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser/node_modules/camelcase": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/yargs-unparser/node_modules/decamelize": {
@@ -5294,9 +5068,9 @@
       }
     },
     "@jest/types": {
-      "version": "27.1.1",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.1.1.tgz",
-      "integrity": "sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.2.4.tgz",
+      "integrity": "sha512-IDO2ezTxeMvQAHxzG/ZvEyA47q0aVfzT95rGFl7bZs/Go0aIucvfDbS2rmnoEdXxlLQhcolmoG/wvL/uKx4tKA==",
       "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -5442,9 +5216,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.173",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.173.tgz",
-      "integrity": "sha512-vv0CAYoaEjCw/mLy96GBTnRoZrSxkGE0BKzKimdR8P3OzrNYNvBgtW7p055A+E8C31vXNUhWKoFCbhq7gbyhFg==",
+      "version": "4.14.175",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.175.tgz",
+      "integrity": "sha512-XmdEOrKQ8a1Y/yxQFOMbC47G/V2VDO1GvMRnl4O75M4GW/abC5tnfzadQYkqEveqRM1dEJGFFegfPNA2vvx2iw==",
       "dev": true
     },
     "@types/lodash.flattendeep": {
@@ -5616,18 +5390,6 @@
         "webdriverio": "7.13.2",
         "yargs": "^17.0.0",
         "yarn-install": "^1.0.0"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/config": {
@@ -5639,17 +5401,6 @@
         "@wdio/types": "7.13.2",
         "deepmerge": "^4.0.0",
         "glob": "^7.1.2"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/local-runner": {
@@ -5666,18 +5417,6 @@
         "async-exit-hook": "^2.0.1",
         "split2": "^3.2.2",
         "stream-buffers": "^3.0.2"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/logger": {
@@ -5703,18 +5442,6 @@
         "@wdio/utils": "7.13.2",
         "expect-webdriverio": "^3.0.0",
         "mocha": "^9.0.0"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/protocols": {
@@ -5745,18 +5472,6 @@
         "fs-extra": "^10.0.0",
         "object-inspect": "^1.10.3",
         "supports-color": "8.1.1"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/runner": {
@@ -5773,18 +5488,6 @@
         "gaze": "^1.1.2",
         "webdriver": "7.13.2",
         "webdriverio": "7.13.2"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/spec-reporter": {
@@ -5799,18 +5502,6 @@
         "chalk": "^4.0.0",
         "easy-table": "^1.1.1",
         "pretty-ms": "^7.0.0"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "@wdio/testingbot-service": {
@@ -5825,18 +5516,15 @@
         "got": "^11.0.2",
         "testingbot-tunnel-launcher": "^1.1.7",
         "webdriverio": "7.13.2"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "dev": true,
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
+      }
+    },
+    "@wdio/types": {
+      "version": "7.13.2",
+      "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
+      "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
+      "requires": {
+        "@types/node": "^15.12.5",
+        "got": "^11.8.1"
       }
     },
     "@wdio/utils": {
@@ -5847,17 +5535,6 @@
         "@wdio/logger": "7.7.0",
         "@wdio/types": "7.13.2",
         "p-iteration": "^1.1.8"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "agent-base": {
@@ -6286,9 +5963,10 @@
       }
     },
     "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
+      "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
+      "dev": true
     },
     "camelcase-keys": {
       "version": "6.2.2",
@@ -6300,6 +5978,11 @@
         "quick-lru": "^4.0.1"
       },
       "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
+        },
         "quick-lru": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -6473,9 +6156,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "core-js-pure": {
-      "version": "3.18.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.0.tgz",
-      "integrity": "sha512-ZnK+9vyuMhKulIGqT/7RHGRok8RtkHMEX/BGPHkHx+ouDkq+MUvf9mfIgdqhpmPDu8+V5UtRn/CbCRc9I4lX4w=="
+      "version": "3.18.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.18.1.tgz",
+      "integrity": "sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ=="
     },
     "core-util-is": {
       "version": "1.0.3",
@@ -6649,17 +6332,6 @@
         "query-selector-shadow-dom": "^1.0.0",
         "ua-parser-js": "^0.7.21",
         "uuid": "^8.0.0"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "devtools-protocol": {
@@ -6749,27 +6421,22 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
-    "esm": {
-      "version": "3.2.25",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
-      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA=="
-    },
     "exit-on-epipe": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz",
       "integrity": "sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw=="
     },
     "expect": {
-      "version": "27.2.1",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.1.tgz",
-      "integrity": "sha512-ekOA2mBtT2phxcoPVHCXIzbJxCvRXhx2fr7m28IgGdZxUOh8UvxvoRz1FcPlfgZMpE92biHB6woIcAKXqR28hA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-27.2.4.tgz",
+      "integrity": "sha512-gOtuonQ8TCnbNNCSw2fhVzRf8EFYDII4nB5NmG4IEV0rbUnW1I5zXvoTntU4iicB/Uh0oZr20NGlOLdJiwsOZA==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.1",
+        "@jest/types": "^27.2.4",
         "ansi-styles": "^5.0.0",
         "jest-get-type": "^27.0.6",
-        "jest-matcher-utils": "^27.2.0",
-        "jest-message-util": "^27.2.0",
+        "jest-matcher-utils": "^27.2.4",
+        "jest-message-util": "^27.2.4",
         "jest-regex-util": "^27.0.6"
       },
       "dependencies": {
@@ -6916,13 +6583,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -7208,9 +6868,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.6.0.tgz",
-      "integrity": "sha512-wShG8vs60jKfPWpF2KZRaAtvt3a20OAn7+IJ6hLPECpSABLcKtFKTTI4ZtH5QcBruBHlq+WsdHWyz0BCZW7svQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.7.0.tgz",
+      "integrity": "sha512-ByY+tjCciCr+9nLryBYcSD50EOGWt95c7tIsKTG1J2ixKKXPvF7Ej3AVd+UfDydAJom3biBGDBALaO79ktwgEQ==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -7233,9 +6893,9 @@
       "dev": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
@@ -7382,15 +7042,15 @@
       }
     },
     "jest-diff": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.0.tgz",
-      "integrity": "sha512-QSO9WC6btFYWtRJ3Hac0sRrkspf7B01mGrrQEiCW6TobtViJ9RWL0EmOs/WnBsZDsI/Y2IoSHZA2x6offu0sYw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-27.2.4.tgz",
+      "integrity": "sha512-bLAVlDSCR3gqUPGv+4nzVpEXGsHh98HjUL7Vb2hVyyuBDoQmja8eJb0imUABsuxBeUVmf47taJSAd9nDrwWKEg==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^27.0.6",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-get-type": {
@@ -7400,30 +7060,30 @@
       "dev": true
     },
     "jest-matcher-utils": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.0.tgz",
-      "integrity": "sha512-F+LG3iTwJ0gPjxBX6HCyrARFXq6jjiqhwBQeskkJQgSLeF1j6ui1RTV08SR7O51XTUhtc8zqpDj8iCG4RGmdKw==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-27.2.4.tgz",
+      "integrity": "sha512-nQeLfFAIPPkyhkDfifAPfP/U5wm1x0fLtAzqXZSSKckXDNuk2aaOfQiDYv1Mgf5GY6yOsxfUnvNm3dDjXM+BXw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",
-        "jest-diff": "^27.2.0",
+        "jest-diff": "^27.2.4",
         "jest-get-type": "^27.0.6",
-        "pretty-format": "^27.2.0"
+        "pretty-format": "^27.2.4"
       }
     },
     "jest-message-util": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.0.tgz",
-      "integrity": "sha512-y+sfT/94CiP8rKXgwCOzO1mUazIEdEhrLjuiu+RKmCP+8O/TJTSne9dqQRbFIHBtlR2+q7cddJlWGir8UATu5w==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-27.2.4.tgz",
+      "integrity": "sha512-wbKT/BNGnBVB9nzi+IoaLkXt6fbSvqUxx+IYY66YFh96J3goY33BAaNG3uPqaw/Sh/FR9YpXGVDfd5DJdbh4nA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@jest/types": "^27.1.1",
+        "@jest/types": "^27.2.4",
         "@types/stack-utils": "^2.0.0",
         "chalk": "^4.0.0",
         "graceful-fs": "^4.2.4",
         "micromatch": "^4.0.4",
-        "pretty-format": "^27.2.0",
+        "pretty-format": "^27.2.4",
         "slash": "^3.0.0",
         "stack-utils": "^2.0.3"
       }
@@ -7778,16 +7438,16 @@
       "dev": true
     },
     "mocha": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.1.tgz",
-      "integrity": "sha512-0wE74YMgOkCgBUj8VyIDwmLUjTsS13WV1Pg7l0SHea2qzZzlq7MDnfbPsHKcELBRk3+izEVkRofjmClpycudCA==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-9.1.2.tgz",
+      "integrity": "sha512-ta3LtJ+63RIBP03VBjMGtSqbe6cWXRejF9SyM9Zyli1CKZJZ+vfCTj3oW24V7wAphMJdpOFLoMI3hjJ1LWbs0w==",
       "dev": true,
       "requires": {
         "@ungap/promise-all-settled": "1.1.2",
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
         "chokidar": "3.5.2",
-        "debug": "4.3.1",
+        "debug": "4.3.2",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",
         "find-up": "5.0.0",
@@ -7798,35 +7458,17 @@
         "log-symbols": "4.1.0",
         "minimatch": "3.0.4",
         "ms": "2.1.3",
-        "nanoid": "3.1.23",
+        "nanoid": "3.1.25",
         "serialize-javascript": "6.0.0",
         "strip-json-comments": "3.1.1",
         "supports-color": "8.1.1",
         "which": "2.0.2",
-        "wide-align": "1.1.3",
         "workerpool": "6.1.5",
         "yargs": "16.2.0",
         "yargs-parser": "20.2.4",
         "yargs-unparser": "2.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          },
-          "dependencies": {
-            "ms": {
-              "version": "2.1.2",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-              "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-              "dev": true
-            }
-          }
-        },
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -7888,9 +7530,9 @@
       "dev": true
     },
     "nanoid": {
-      "version": "3.1.23",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.23.tgz",
-      "integrity": "sha512-FiB0kzdP0FFVGDKlRLEQ1BgDzU87dy5NnzjeW9YZNt+/c3+q82EQDUwniSAUxp/F0gFNI1ZhKU1FqYsMuqZVnw==",
+      "version": "3.1.25",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.25.tgz",
+      "integrity": "sha512-rdwtIXaXCLFAQbnfqDRnI6jaRHp9fTcYBjtFKE8eezcZ7LuLjhUaQGNeMXf1HmRoCH32CLz6XwX0TtxEOS/A3Q==",
       "dev": true
     },
     "node-fetch": {
@@ -8129,13 +7771,13 @@
       }
     },
     "pretty-format": {
-      "version": "27.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.0.tgz",
-      "integrity": "sha512-KyJdmgBkMscLqo8A7K77omgLx5PWPiXJswtTtFV7XgVZv2+qPk6UivpXXO+5k6ZEbWIbLoKdx1pZ6ldINzbwTA==",
+      "version": "27.2.4",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.2.4.tgz",
+      "integrity": "sha512-NUjw22WJHldzxyps2YjLZkUj6q1HvjqFezkB9Y2cklN8NtVZN/kZEXGZdFw4uny3oENzV5EEMESrkI0YDUH8vg==",
       "dev": true,
       "requires": {
-        "@jest/types": "^27.1.1",
-        "ansi-regex": "^5.0.0",
+        "@jest/types": "^27.2.4",
+        "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
         "react-is": "^17.0.1"
       },
@@ -8488,9 +8130,9 @@
       }
     },
     "rxjs": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.1.tgz",
-      "integrity": "sha512-vNenx7gqjPyeKpRnM6S5Ksm/oFTRijWWzYlRON04KaehZ3YjDwEmVjGUGo0TKWVjeNXOujVRlh0K1drUbcdPkw==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.3.0.tgz",
+      "integrity": "sha512-p2yuGIg9S1epc3vrjKf6iVb3RCaAYjYskkO+jHIaV0IjOPlJop4UnodOoFb2xeNwlguqLYvGw1b1McillYb5Gw==",
       "dev": true,
       "requires": {
         "tslib": "~2.1.0"
@@ -8540,9 +8182,9 @@
       }
     },
     "signal-exit": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.4.tgz",
-      "integrity": "sha512-rqYhcAnZ6d/vTPGghdrw7iumdcbXpsk1b8IG/rz+VWV51DM0p7XCtMoJ3qhPLIbp3tvyt3pKRbaaEMZYpHto8Q==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.5.tgz",
+      "integrity": "sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==",
       "dev": true
     },
     "slash": {
@@ -8620,22 +8262,22 @@
       }
     },
     "string-width": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
-      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
       "requires": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.0"
+        "strip-ansi": "^6.0.1"
       }
     },
     "strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -8891,17 +8533,6 @@
         "got": "^11.0.2",
         "ky": "^0.28.5",
         "lodash.merge": "^4.6.1"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "webdriverio": {
@@ -8938,17 +8569,6 @@
         "rgb2hex": "0.2.5",
         "serialize-error": "^8.0.0",
         "webdriver": "7.13.2"
-      },
-      "dependencies": {
-        "@wdio/types": {
-          "version": "7.13.2",
-          "resolved": "https://registry.npmjs.org/@wdio/types/-/types-7.13.2.tgz",
-          "integrity": "sha512-uTU9e4QjOIME0z4HIEwefitGNjvgeekA4G8EnOGPpgI9JCoR6kjl3X6T58tilDtZVpTC54XwjpjHESz5MwQt2w==",
-          "requires": {
-            "@types/node": "^15.12.5",
-            "got": "^11.8.1"
-          }
-        }
       }
     },
     "which": {
@@ -8957,42 +8577,6 @@
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "requires": {
         "isexe": "^2.0.0"
-      }
-    },
-    "wide-align": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
-      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-      "dev": true,
-      "requires": {
-        "string-width": "^1.0.2 || 2"
-      },
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "dev": true,
-          "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^3.0.0"
-          }
-        }
       }
     },
     "workerpool": {
@@ -9035,9 +8619,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
-      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.2.1.tgz",
+      "integrity": "sha512-XfR8du6ua4K6uLGm5S6fA+FIJom/MdJcFNVY8geLlp2v8GYbOXD4EB1tPNZsRn4vBzKGMgb5DRZMeWuFc2GO8Q==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",
@@ -9066,12 +8650,6 @@
         "is-plain-obj": "^2.1.0"
       },
       "dependencies": {
-        "camelcase": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
-          "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==",
-          "dev": true
-        },
         "decamelize": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha -r esm test/specs"
+    "test": "mocha test/specs"
   },
   "type": "module",
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": {
+    "node": ">=15.0"
+  },
   "devDependencies": {
     "@wdio/cli": "^7.14.0",
     "@wdio/local-runner": "~7.13.2",
@@ -20,7 +23,6 @@
     "wdio-chromedriver-service": "^7.2.0"
   },
   "dependencies": {
-    "esm": "^3.2.25",
     "glob": "^7.2.0",
     "meow": "^9.0",
     "partition-all": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "glob": "^7.2.0",
-    "meow": "^9.0",
+    "meow": "^10.0",
     "partition-all": "^1.0.1",
     "promise-queue": "^2.2.5",
     "toml": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "mocha -r esm test/specs"
   },
+  "type": "module",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/src/CliRequestFactory.js
+++ b/src/CliRequestFactory.js
@@ -1,7 +1,7 @@
 import meow from "meow";
 import path from "path";
-import testFunctions from "./test_functions";
-import {ScreenshotsRequest} from "./ScreenshotGenerator";
+import testFunctions from "./test_functions/index.js";
+import {ScreenshotsRequest} from "./ScreenshotGenerator.js";
 
 export class CliRequestFactory {
 
@@ -56,9 +56,11 @@ export class CliRequestFactory {
 			console.log( `ERROR: Please provide an existing campaign name! \nSee --help for usage instructions.` );
 			process.exit( 2 );
 		}
+		console.log("cwd is ", this.cwd)
 		const campaignName = cli.input[0];
 		const screenshotPath = path.join( this.cwd, cli.flags.screenshotPath.toString() );
 		const configPath = path.join( this.cwd, cli.flags.configPath.toString() );
+		console.log("configPath is ", configPath)
 		const concurrentRequestLimit = cli.flags.concurrentRequestLimit;
 		const testFunctionName = cli.flags.testFunctionName;
 

--- a/src/ConfigurationParser.js
+++ b/src/ConfigurationParser.js
@@ -1,8 +1,8 @@
-import {BANNER as BANNER_DIMENSION} from "./Dimensions";
+import {BANNER as BANNER_DIMENSION} from "./Dimensions.js";
 
-const toml = require( 'toml' );
-import {TestCaseGenerator} from "./TestCaseGenerator";
-import objectToMap from "./ObjectToMap";
+import toml from 'toml';
+import {TestCaseGenerator} from "./TestCaseGenerator.js";
+import objectToMap from "./ObjectToMap.js";
 
 // Campaign keys
 const PREVIEW_URL = 'preview_url';

--- a/src/SLCapabilityFactory.js
+++ b/src/SLCapabilityFactory.js
@@ -1,4 +1,4 @@
-import {DEVICE, PLATFORM, ORIENTATION, RESOLUTION} from "./Dimensions";
+import {DEVICE, PLATFORM, ORIENTATION, RESOLUTION} from "./Dimensions.js";
 
 const DEVICE_NAMES = new Map( [
 	[ 'iphone_xs_max', { deviceName: 'iPhone XS Max Simulator', platformName: 'iOS', browserName: 'Safari', appiumVersion: '1.16.0', platformVersion: '13.2' } ],

--- a/src/ScreenshotGenerator.js
+++ b/src/ScreenshotGenerator.js
@@ -1,9 +1,9 @@
 import fs from "fs";
-import {ConfigurationParser} from "./ConfigurationParser";
+import {ConfigurationParser} from "./ConfigurationParser.js";
 import path from "path";
-import {createImageWriter} from "./writeImageData";
-import {serializeMapToArray} from "./serializeMapToArray";
-import {TestCaseSerializer} from "./TestcaseMetadata";
+import {createImageWriter} from "./writeImageData.js";
+import {serializeMapToArray} from "./serializeMapToArray.js";
+import {TestCaseSerializer} from "./TestcaseMetadata.js";
 
 const METADATA_FILENAME = 'metadata.json';
 

--- a/src/TBCapabilityFactory.js
+++ b/src/TBCapabilityFactory.js
@@ -1,4 +1,4 @@
-import {DEVICE, PLATFORM, ORIENTATION, RESOLUTION} from "./Dimensions";
+import {DEVICE, PLATFORM, ORIENTATION, RESOLUTION} from "./Dimensions.js";
 
 const DEVICE_NAMES = new Map( [
 	//s6 is responding very slowly or not at all

--- a/src/TestCase.js
+++ b/src/TestCase.js
@@ -1,4 +1,4 @@
-import { DEVICE, PLATFORM, RESOLUTION} from "./Dimensions";
+import { DEVICE, PLATFORM, RESOLUTION} from "./Dimensions.js";
 
 const PLATFORM_EXCLUDED_RESOLUTIONS = [
 	{

--- a/src/TestCaseGenerator.js
+++ b/src/TestCaseGenerator.js
@@ -1,6 +1,6 @@
-import cartesian from './Cartesian';
-import {TestCase} from "./TestCase";
-import {ALLOWED_DIMENSIONS, BANNER, DEVICE, PLATFORM} from "./Dimensions";
+import cartesian from './Cartesian.js';
+import {TestCase} from "./TestCase.js";
+import {ALLOWED_DIMENSIONS, BANNER, DEVICE, PLATFORM} from "./Dimensions.js";
 
 export class TestCaseGenerator {
 	testCases;

--- a/src/test_functions/index.js
+++ b/src/test_functions/index.js
@@ -1,5 +1,5 @@
-import { shootBanner } from './shootBanner';
-import { shootBanner as shootOldBanner } from './shootOldBanner';
+import { shootBanner } from './shootBanner.js';
+import { shootBanner as shootOldBanner } from './shootOldBanner.js';
 
 export const testFunctions = {
 	shootBanner,

--- a/src/test_functions/shootBanner.js
+++ b/src/test_functions/shootBanner.js
@@ -5,7 +5,7 @@
  * @param {function} writeImageData
  * @return {Promise<void>}
  */
-import {TestCaseFinishedState, TestCaseIsRunningState} from "../TestCase";
+import {TestCaseFinishedState, TestCaseIsRunningState} from "../TestCase.js";
 
 export async function shootBanner( browser, testCase, writeImageData ) {
 	testCase.updateState( new TestCaseIsRunningState( "Testcase started" ) );

--- a/test/specs/ConfigurationParser.js
+++ b/test/specs/ConfigurationParser.js
@@ -1,7 +1,8 @@
-const assert = require('assert');
-const fs = require('fs');
-import {ConfigurationParser} from '../../src/ConfigurationParser';
-import { TestCaseGenerator } from "../../src/TestCaseGenerator";
+import { strict as assert } from 'assert';
+import fs from 'fs';
+import { URL } from 'url'; 
+import {ConfigurationParser} from '../../src/ConfigurationParser.js';
+import { TestCaseGenerator } from "../../src/TestCaseGenerator.js";
 
 const CAMPAIGN = 'desktop';
 const VALID_TOML = '/../data/valid.toml';
@@ -10,6 +11,8 @@ const MISSING_PREVIEW_URL_TOML = '/../data/missing_preview_url.toml';
 const MISSING_TEST_MATRIX_TOML = '/../data/missing_test_matrix.toml';
 
 describe('CampaignScreenshotGenerator', () => {
+
+	const __dirname = new URL( '.', import.meta.url ).pathname;
 
 	it('throws exception on toml parse error', () => {
 		assert.throws( () => {

--- a/test/specs/MetadataSummarizer.js
+++ b/test/specs/MetadataSummarizer.js
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import MetadataSummarizer from "../../src/MetadataSummarizer";
+import MetadataSummarizer from "../../src/MetadataSummarizer.js";
 
 function createMetaData( fieldGenerator ) {
 	const metaData = [];

--- a/test/specs/SLCapabilityFactory.js
+++ b/test/specs/SLCapabilityFactory.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
-import { CapabilityFactory } from "../../src/SLCapabilityFactory";
-import { TestCase } from "../../src/TestCase";
-import {BANNER, DEVICE, PLATFORM, RESOLUTION} from "../../src/Dimensions";
+import { CapabilityFactory } from "../../src/SLCapabilityFactory.js";
+import { TestCase } from "../../src/TestCase.js";
+import {BANNER, DEVICE, PLATFORM, RESOLUTION} from "../../src/Dimensions.js";
 
 
 

--- a/test/specs/TBCapabilityFactory.js
+++ b/test/specs/TBCapabilityFactory.js
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
-import { CapabilityFactory } from "../../src/TBCapabilityFactory";
-import { TestCase } from "../../src/TestCase";
-import {BANNER, DEVICE, PLATFORM, RESOLUTION} from "../../src/Dimensions";
+import { CapabilityFactory } from "../../src/TBCapabilityFactory.js";
+import { TestCase } from "../../src/TestCase.js";
+import {BANNER, DEVICE, PLATFORM, RESOLUTION} from "../../src/Dimensions.js";
 
 
 

--- a/test/specs/TestCase.js
+++ b/test/specs/TestCase.js
@@ -1,8 +1,6 @@
-import {BANNER, RESOLUTION, PLATFORM} from "../../src/Dimensions";
-
-const assert = require('assert');
-
-import { TestCase, INVALID_REASON_REQUIRED, INVALID_REASON_RESOLUTION } from "../../src/TestCase";
+import { strict as assert } from 'assert';
+import {BANNER, RESOLUTION, PLATFORM} from "../../src/Dimensions.js";
+import { TestCase, INVALID_REASON_REQUIRED, INVALID_REASON_RESOLUTION } from "../../src/TestCase.js";
 
 describe('TestCase', () => {
 	const dimensions = [PLATFORM, RESOLUTION, BANNER];

--- a/test/specs/TestCaseGenerator.js
+++ b/test/specs/TestCaseGenerator.js
@@ -1,6 +1,6 @@
 import { strict as assert } from 'assert';
-import {TestCaseGenerator} from "../../src/TestCaseGenerator";
-import {BANNER, DEVICE, PLATFORM} from "../../src/Dimensions";
+import {TestCaseGenerator} from "../../src/TestCaseGenerator.js";
+import {BANNER, DEVICE, PLATFORM} from "../../src/Dimensions.js";
 
 const BANNER_URL = 'http://de.wikipedia.org/{{PLACEHOLDER}}';
 const PLACEHOLDER = '{{PLACEHOLDER}}';

--- a/test/specs/basic.js
+++ b/test/specs/basic.js
@@ -1,4 +1,4 @@
-const assert = require('assert')
+import { strict as assert } from 'assert';
 
 describe('webdriver.io page', () => {
     xit('should have the right title', () => {


### PR DESCRIPTION
Use `import` consistently and add suffixes to all locally imported files

This fixes incompatibilities with the CLI-library meow and the `env` command on Linux (since we no longer need to register the `esm` module).

This fixes one of the errors mentioned in #210 