### PR TITLE
Fix shebang line of shellscript

### DIFF
--- a/remote_metadata_summary.sh
+++ b/remote_metadata_summary.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ -z "$1" ]; then
   echo "You must provide the remote server name!"


### PR DESCRIPTION
The script now also works on Linux. On some versions of macOS, /bin/sh
is bash-compatible, which made this script work.
