### PR TITLE
Adapt README for Docker-first usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ campaign_info.toml
 
 # might contain screenshot provider credentials
 .env
+
+# Docker-compose override files for differengt paths to screenshot
+# directory and banner configuration.
+docker-compose.dev.yml
+docker-compose.prod.yml

--- a/README.md
+++ b/README.md
@@ -2,17 +2,27 @@
 
 This is a tool for taking screenshots of WMDE fundraising banners on wikipedia.org in different browsers and resolutions.
 
-## Configuration & Setup
+To improve performance, the system consists of parallelizable worker scripts for taking screenshots and processing metadata, connected by a message queue.
+
+## Configuration
 The screenshot background worker needs credentials for the Testingbot service. Put these in the file named `.env`.
 You can copy and adapt the file `env-template`.
 
-To install the dependencies run
+Have a look at the `docker-compose.yml` file to see the paths
+mounted into the containers:
 
-    npm install
+- The one mounted to `banner-shots` will contain the screenshots and metadata.
+- The one mounted to `campaign_info.toml` must exist and contain a banner
+	configuration file (see below).
 
-or
+Do not change the paths in `docker-compose.yml` file directly! If you
+can't provide the required paths in your local setup, create an [override
+docker-compose
+file](https://docs.docker.com/compose/extends/#multiple-compose-files) and
+use the `-f` parameter to specify additional file for all `docker-compose`
+commands. Example:
 
-    docker run --rm -v $(pwd):/app -w /app node:16-alpine npm install
+	docker-compose -f docker-compose.yml -f docker-compose.prod.yml up -d
 
 ## Starting the Environment
 
@@ -27,36 +37,23 @@ local machine.
 
 Run the screenshot tool with the following command
 
-    npx ts-node queue_screenshots.ts -c ../fundraising-banners/campaign_info.toml <CAMPAIGN_NAME>
+    docker-compose exec screenshot_worker_1 npx ts-node queue_screenshots.ts <CAMPAIGN_NAME>
 
-The `-c` parameter is for locating the campaign configuration from the
-[`wmde/fundraising-banners`
-repository](https://github.com/wmde/fundraising-banners).
+The `queue_screenshot` tool will look for the file `campaign_info.toml`,
+create a test matrix and queue the tests. 
+
 `<CAMPAIGN_NAME>` must be one of the configuration keys of that
 configuration file, e.g. `desktop` or `mobile`.
 
 The background workers will create a directory inside the `banner-shots` directory. The campaign directory contains the 
 screenshot images and file `metadata.json` with all the metadata about the test case.
 
-Instead of using the `-c` parameter, you can also create a symbolic link
-from your local copy of `wmde/fundraising-banners` to the screenshot tool
-directory.
-
-### Running inside the docker context
-
-To enable Docker to access RabbitMQ you need to figure out the network name of the `docker-compose` installation. 
-Usually that's the name of the directory of the `docker-compose.yml` file with the suffix `_default`. You can show all 
-networks with the command
-
-    docker network ls
-
-Then you can run the script with the following command:
-
-    docker run --rm --network SCREENSHOT_NETWORK_NAME -v /path/to/banner/config:/app/campaign_info.toml -v $(pwd):/app \
-        -w /app node:16-alpine npx ts-node queue_screenshots.ts -u ampq://rabbitmq <CAMPAIGN_NAME>
-
 
 ### Configuration file format
+
+This is the same file used in the [`wmde/fundraising-banners`
+repository](https://github.com/wmde/fundraising-banners) for configuring
+campaigns. It also contains test matrix configurations.
 
 The TOML file has the following (abbreviated) format
 
@@ -82,11 +79,11 @@ resolution = ["1280x960", "1024x768"]
 `[campaign]` is the key you pass to the screenshot tool. The TOML file can
 contain several campaigns, each one for a specific *channel* (a
 combination of device type and language). `[campaign]` in the example
-above is just a placeholder, the campaign name can consist of all
+above is a placeholder, the campaign name can consist of all
 alphanumeric characters, e.g. `desktop` or `ipad_en`.
 
-Each campaign will also have at least one banner, configured with the
-`[campaign.banners.BANNER_NAME]`. Usually, `BANNER_NAME` is `ctrl` or `var`.
+Each campaign will also have at least one banner, configured in the 
+`[campaign.banners.BANNER_NAME]` section. Usually, `BANNER_NAME` is `ctrl` or `var`.
 Each banner has a unique `pagename` which designates its page name in
 CentralNotice. To preview a banner (and to render the screenshot), you
 replace the `{{PLACEHOLDER}}` with the banner name in the `preview_url` of
@@ -115,7 +112,40 @@ Add a different test function to the `src/test_functions/` directory,
 im- and export it in `src/test_functions/index.js` and specify its name in
 `testFunctionName` in `index.js`.
 
-## Running the unit tests
+## Local development
+
+To avoid the build cycle of the Docker images, you can also develop
+locally.
+
+### Installing the dependencies
+
+	npm install
+
+### Run a rabbitmq instance
+
+	docker run -d --name amqp.test -p 5672:5672 rabbitmq
+
+
+### Running the workers
+
+You have to set the environment variables `QUEUE_URL` (e.g. `amqp://localhost`), `TB_SECRET` and `TB_KEY` (authentication data for testingbot) before running the scripts.
+
+	npx ts-node metadata_worker.ts
+	npx ts-node screenshot_worker.ts
+
+Instead of the full-fledged screenshot worker you can also run
+`simple_worker.js` which just echoes the data it receives.
+
+
+### Running the screenshot tool
+
+	npx ts-node queue_screenshots.ts -c path/to/campaign_info.toml <CAMPAIGN_NAME>
+
+Instead of using the `-c` parameter, you can also create a symbolic link
+from your local copy of `wmde/fundraising-banners` to the screenshot tool
+directory.
+
+### Running the unit tests
 
     npm run test
 


### PR DESCRIPTION
In production, it's easier to run all commands in the Docker
environment. This change shows how to queue screenshots in the Docker
environment, how to mount the screenshot and config directory with
override files and how to do local development without Docker.

This is for https://phabricator.wikimedia.org/T295061
