### PR TITLE
catch failing browser start

### DIFF
--- a/metadata_worker.ts
+++ b/metadata_worker.ts
@@ -39,6 +39,8 @@ consumer.consumeMetaDataQueue( async ( msgData: MetadataMessage ) => {
             );
             repo.saveMetadata(initialMetadata);
             showMessage(`Initialized metadata file for ${initialMetadata.campaign}`);
+			// Trigger metadata summary update, so the new test shows up immediately
+			await producer.sendMetadataSummary({msgType: 'summary'});
             break;
         case "update":
             const testCase = unserializeTestCase(msgData.testCase);

--- a/screenshot_worker.ts
+++ b/screenshot_worker.ts
@@ -67,7 +67,15 @@ consumer.consumeScreenshotQueue( async (msgData: TestCaseMessage) => {
 	const onTestCaseStateChange = getTestCaseStateChangeFunction( msgData.trackingName )
 
 	showMessage( `Creating a browser instance for test ${testCase.getName()}` );
-	const browser = await browserFactory.getBrowser(testCase);
+	let browser;
+	try {
+		browser = await browserFactory.getBrowser(testCase);
+	} catch ( e ) {
+		onTestCaseStateChange( testCase, new TestCaseFailedState( 'Failed creating remote browser instance: ' + e.message ) );
+		showMessage( `Could not create browser instance for test ${testCase.getName()}` );
+		showMessage( e );
+		return;
+	}
 
 	showMessage( `Taking screenshot for test ${testCase.getName()}` );
 	let testFunction;


### PR DESCRIPTION
- Catch failing browser instantiation
- Trigger metadata summary after starting test run
