### PR TITLE
Adapt code for new Vue banners

### DIFF
--- a/src/ConfigurationParser.ts
+++ b/src/ConfigurationParser.ts
@@ -14,7 +14,7 @@ const CAMPAIGN_TRACKING = 'campaign_tracking';
 const PAGE_NAME = 'pagename';
 
 // Placeholder in PREVIEW_URL
-const PLACEHOLDER = '{{PLACEHOLDER}}';
+const PLACEHOLDER = '{{banner}}';
 
 
 /**


### PR DESCRIPTION
Change test function to work with the new banner state classes.
It's also more efficient, because it can detect the "banner
not shown" state, avoiding unneccesary wait times

https://phabricator.wikimedia.org/T349528
