### PR TITLE
Group patch update PRs by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
       interval: "weekly"
     reviewers:
       - "wmde/funtech-core"
+    groups:
+      patch-updates:
+        update-types:
+          - patch


### PR DESCRIPTION
- dependabot allows to group pull requests: docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
- we can group safely group patch updates to reduce the weekly PR flood on github