### PR TITLE
Change channel names

### DIFF
--- a/src/CommandLine/determineCampaignFromBranchName.ts
+++ b/src/CommandLine/determineCampaignFromBranchName.ts
@@ -1,12 +1,12 @@
 /**
- * This function checks a branch or tag name like C21_WMDE_Test_07 and 
+ * This function checks a branch or tag name like C21_WMDE_Test_07 and
  * returns a channel name for the campaign_info.toml file.
  */
 export function determineCampaignFromBranchName( branchName: string ): string {
 	const campaignParts = new Map( branchName.
 								  toLowerCase().
 								  split("_").
-								  map( part => [ part, true ] ) 
+								  map( part => [ part, true ] )
 								 );
 	if ( !campaignParts.has('wmde') && !campaignParts.has('wpde') ) {
 		throw new Error('Name does not contain WPDE or WMDE');
@@ -14,19 +14,19 @@ export function determineCampaignFromBranchName( branchName: string ): string {
 
 	if ( campaignParts.has('wpde') ) {
 		if ( Array.from( campaignParts.keys() ).find( k => /mob/.test(k) ) ) {
-			return 'wikipediade_mobile';
+			return 'wpde_mobile';
 		}
-		return 'wikipediade';
+		return 'wpde_desktop';
 	}
 
 	if ( campaignParts.has('mobile') ) {
 		return campaignParts.has('en') ? 'mobile_english' : 'mobile';
 	}
-	
+
 	if ( campaignParts.has('ipad') || campaignParts.has('pad') ) {
 		return campaignParts.has('en') ? 'pad_en' : 'pad';
 	}
-	
+
 
 	return campaignParts.has('en') ? 'english' : 'desktop';
 }


### PR DESCRIPTION
We wanted to have a 1:1 relation between channel names and banner
directory names in the banner repository and renamed the channels
`wikipediade` to `wpde_desktop` and `wikipediade_mobile` to `wpde_mobile`.

Ticket: https://phabricator.wikimedia.org/T369276
