### PR TITLE
Update banner name convention

### DIFF
--- a/campaign_info.example.toml
+++ b/campaign_info.example.toml
@@ -3,10 +3,10 @@ preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACE
 campaign_tracking='00-ba-200416'
 
 [desktop.banners.ctrl]
-pagename = "B20_WMDE_Test_05_ctrl"
+pagename = "WMDE_FR_2025_Test_05_ctrl"
 
 [desktop.banners.var]
-pagename = "B20_WMDE_Test_05_var"
+pagename = "WMDE_FR_2025_Test_05_var"
 
 [desktop.test_matrix]
 platform = [ "edge",
@@ -30,7 +30,7 @@ preview_url = 'https://de.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLACE
 campaign_tracking='00-test-200416'
 
 [test.banners.ctrl]
-pagename = "B20_WMDE_Test_05_ctrl"
+pagename = "WMDE_FR_2025_Test_05_ctrl"
 
 
 [test.test_matrix]
@@ -43,7 +43,7 @@ preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLA
 campaign_tracking='00-mobile-200416'
 
 [mobile.banners.ctrl]
-pagename = "B20_WMDE_Test_Mobile"
+pagename = "WMDE_FR_2025_Test_Mobile"
 
 [mobile.test_matrix]
 device = [
@@ -67,7 +67,7 @@ preview_url = 'https://de.m.wikipedia.org/wiki/Wikipedia:Hauptseite?banner={{PLA
 campaign_tracking='00-mobile-test-200416'
 
 [mobile_test.banners.ctrl]
-pagename = "B20_WMDE_Test_Mobile"
+pagename = "WMDE_FR_2025_Test_Mobile"
 
 [mobile_test.test_matrix]
 device = [

--- a/test/specs/determineCampaignFromBranchName.spec.ts
+++ b/test/specs/determineCampaignFromBranchName.spec.ts
@@ -4,76 +4,76 @@ import {determineCampaignFromBranchName } from '../../src/CommandLine/determineC
 describe("determineCampaignFromBranchName", () => {
 	it("returns desktop for WMDE prefix without other modifiers", () => {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_Test_01'),
 			'desktop'
 		);
 	} );
 
 	it("returns english for WMDE prefix and EN part", () => {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_Test_EN_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_Test_EN_01'),
 			'english'
 		);
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_EN_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_EN_Test_01'),
 			'english'
 		);
 	} );
 
 	it("returns mobile for mobile campaigns", () =>  {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_Mobile_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_Mobile_Test_01'),
 			'mobile'
 		);
 	} );
 
 	it("returns mobile_english for English mobile campaigns", () =>  {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_Mobile_EN_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_Mobile_EN_Test_01'),
 			'mobile_english'
 		);
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_EN_Mobile_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_EN_Mobile_Test_01'),
 			'mobile_english'
 		);
 	} );
 
 	it("returns pad for iPad campaigns", () =>  {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_Pad_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_Pad_Test_01'),
 			'pad'
 		);
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_iPad_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_iPad_Test_01'),
 			'pad'
 		);
 	} );
 
 	it("returns pad_en for English iPad campaigns", () =>  {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_pad_EN_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_pad_EN_Test_01'),
 			'pad_en'
 		);
 		assert.equal(
-			determineCampaignFromBranchName('C21_WMDE_EN_iPad_Test_01'),
+			determineCampaignFromBranchName('WMDE_FR_2025_EN_iPad_Test_01'),
 			'pad_en'
 		);
 	} );
 
 	it("returns wikipediade for WPDE prefix without other modifiers", () => {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WPDE_Test_01'),
+			determineCampaignFromBranchName('WPDE_FR_2025_Test_01'),
 			'wpde_desktop'
 		);
 	} );
 
 	it("returns wikipediade_mobile for WPDE prefix without other modifiers", () => {
 		assert.equal(
-			determineCampaignFromBranchName('C21_WPDE_Test_Mobile_01'),
+			determineCampaignFromBranchName('WPDE_FR_2025_Test_Mobile_01'),
 			'wpde_mobile'
 		);
 		assert.equal(
-			determineCampaignFromBranchName('C21_WPDE_Test_Mob01'),
+			determineCampaignFromBranchName('WPDE_FR_2025_Test_Mob01'),
 			'wpde_mobile'
 		);
 	} );


### PR DESCRIPTION
The CN admins have asked us to change the format
of our campaign and banner names eg:

WMDE_FR_2025_Mobile_DE_01

This adds tests to ensure that the screenshot tool
works with them.

Ticket: https://phabricator.wikimedia.org/T397706